### PR TITLE
Replace deprecated toml extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Extensions used by Nimble",
   "repository": "https://github.com/nimblehq/vscode-extension-pack",
   "publisher": "nimble",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "engines": {
     "vscode": "^1.76.0"
   },
@@ -18,7 +18,6 @@
   },
   "extensionPack": [
     "aliariff.vscode-erb-beautify",
-    "bungcip.better-toml",
     "CraigMaslowski.erb",
     "eamodio.gitlens",
     "GitHub.copilot",
@@ -41,6 +40,7 @@
     "samuel-pordeus.elixir-test",
     "shardulm94.trailing-spaces",
     "Shopify.ruby-lsp",
+    "tamasfe.even-better-toml",
     "znck.grammarly"
   ]
 }


### PR DESCRIPTION
## What happened 👀

[Better toml](https://marketplace.visualstudio.com/items?itemName=bungcip.better-toml) extension was deprecated and it had to be replaced with [even better toml](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml) extension.

<img width="656" alt="Screen Shot 2023-07-27 at 09 07 16" src="https://github.com/nimblehq/vscode-extension-pack/assets/475367/607cd6c1-08a3-4ea7-935e-85d88fbf9cf0">

## Proof Of Work 📹

N/A
